### PR TITLE
Add isPromise function

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const containsIdentifier = require('./lib/contains-identifier');
 
 module.exports = {
+	computeStaticExpression: require('./lib/compute-static-expression'),
 	containsIdentifier: containsIdentifier.containsIdentifier,
 	getPropertyName: require('./lib/get-property-name'),
 	getRequireSource: require('./lib/get-require-source'),

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = {
 	containsIdentifier: containsIdentifier.containsIdentifier,
 	getPropertyName: require('./lib/get-property-name'),
 	getRequireSource: require('./lib/get-require-source'),
+	isPromise: require('./lib/is-promise'),
 	isStaticRequire: require('./lib/is-static-require'),
 	someContainIdentifier: containsIdentifier.someContainIdentifier
 };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const containsIdentifier = require('./lib/contains-identifier');
 
 module.exports = {
 	containsIdentifier: containsIdentifier.containsIdentifier,
+	getPropertyName: require('./lib/get-property-name'),
 	getRequireSource: require('./lib/get-require-source'),
 	isStaticRequire: require('./lib/is-static-require'),
 	someContainIdentifier: containsIdentifier.someContainIdentifier

--- a/lib/compute-static-expression.js
+++ b/lib/compute-static-expression.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const zip = require('lodash.zip');
+
+const toValue = value => ({value});
+
+function computeTemplateLiteral(node) {
+	const expressions = node.expressions.map(computeStaticExpression);
+
+	if (expressions.some(expression => expression === undefined)) {
+		return undefined;
+	}
+
+	const quasi = node.quasis.map(quasis => quasis.value.cooked);
+	const value = zip(quasi, expressions.map(expr => expr.value))
+		.reduce((res, elts) => res.concat(elts))
+		.filter(Boolean)
+		.join('');
+
+	return toValue(value);
+}
+
+function computeBinaryExpression(operator, leftExpr, rightExpr) { // eslint-disable-line complexity
+	if (!leftExpr || !rightExpr) {
+		return undefined;
+	}
+
+	const left = leftExpr.value;
+	const right = rightExpr.value;
+
+	switch (operator) { // eslint-disable-line default-case
+		case '+': return toValue(left + right);
+		case '-': return toValue(left - right);
+		case '*': return toValue(left * right);
+		case '/': return toValue(left / right);
+		case '%': return toValue(left % right);
+		case '**': return toValue(Math.pow(left, right));
+		case '<<': return toValue(left << right);
+		case '>>': return toValue(left >> right);
+		case '>>>': return toValue(left >>> right);
+		case '&': return toValue(left & right);
+		case '|': return toValue(left | right);
+		case '^': return toValue(left | right);
+		case '&&': return toValue(left && right);
+		case '||': return toValue(left || right);
+		case '===': return toValue(left === right);
+		case '!==': return toValue(left !== right);
+		case '==': return toValue(left == right); // eslint-disable-line eqeqeq
+		case '!=': return toValue(left != right); // eslint-disable-line eqeqeq
+		case '<': return toValue(left < right);
+		case '>': return toValue(left > right);
+		case '<=': return toValue(left <= right);
+		case '>=': return toValue(left >= right);
+	}
+}
+
+function applyUnaryOperator(operator, expr) {
+	if (!expr) {
+		return undefined;
+	}
+
+	const value = expr.value;
+
+	switch (operator) { // eslint-disable-line default-case
+		case '+': return toValue(+value); // eslint-disable-line no-implicit-coercion
+		case '-': return toValue(-value);
+		case '!': return toValue(!value);
+		case '~': return toValue(~value);
+	}
+}
+
+function computeConditionalExpression(test, consequent, alternate) {
+	if (!test) {
+		return undefined;
+	}
+
+	return test.value ? consequent : alternate;
+}
+
+function computeStaticExpression(node) {
+	if (!node) {
+		return undefined;
+	}
+
+	switch (node.type) {
+		case 'Identifier':
+			return node.name === 'undefined' ? toValue(undefined) : undefined;
+		case 'Literal':
+			return toValue(node.value);
+		case 'TemplateLiteral':
+			return computeTemplateLiteral(node);
+		case 'UnaryExpression':
+			return applyUnaryOperator(node.operator, computeStaticExpression(node.argument));
+		case 'BinaryExpression': {
+			return computeBinaryExpression(
+				node.operator,
+				computeStaticExpression(node.left),
+				computeStaticExpression(node.right)
+			);
+		}
+		case 'LogicalExpression': {
+			return computeBinaryExpression(
+				node.operator,
+				computeStaticExpression(node.left),
+				computeStaticExpression(node.right)
+			);
+		}
+		case 'ConditionalExpression':
+			return computeConditionalExpression(
+				computeStaticExpression(node.test),
+				computeStaticExpression(node.consequent),
+				computeStaticExpression(node.alternate)
+			);
+		default:
+			return undefined;
+	}
+}
+
+module.exports = computeStaticExpression;

--- a/lib/get-property-name.js
+++ b/lib/get-property-name.js
@@ -1,16 +1,18 @@
 'use strict';
 
+const computeStaticExpression = require('./compute-static-expression');
+
 function getPropertyName(node) {
-	if (node && node.type === 'MemberExpression') {
-		if (node.property.type === 'Identifier' && node.computed === false) {
-			return node.property.name;
-		}
-		if (node.property.type === 'Literal') {
-			return node.property.value;
-		}
+	if (!node || node.type !== 'MemberExpression') {
+		return undefined;
 	}
 
-	return undefined;
+	if (node.property.type === 'Identifier' && node.computed === false) {
+		return node.property.name;
+	}
+
+	const expression = computeStaticExpression(node.property);
+	return expression && expression.value;
 }
 
 module.exports = getPropertyName;

--- a/lib/get-property-name.js
+++ b/lib/get-property-name.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function getPropertyName(node) {
+	if (node && node.type === 'MemberExpression') {
+		if (node.property.type === 'Identifier' && node.computed === false) {
+			return node.property.name;
+		}
+		if (node.property.type === 'Literal') {
+			return node.property.value;
+		}
+	}
+
+	return undefined;
+}
+
+module.exports = getPropertyName;

--- a/lib/is-promise.js
+++ b/lib/is-promise.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const getPropertyName = require('./get-property-name');
+
+const prototypeMethods = ['then', 'catch'];
+const staticMethods = ['resolve', 'reject', 'race', 'all'];
+
+function containsThenOrCatch(node) {
+	return Boolean(node) &&
+		node.type === 'CallExpression' &&
+		node.callee.type === 'MemberExpression' &&
+		prototypeMethods.indexOf(getPropertyName(node.callee)) !== -1;
+}
+
+function isPromiseStaticMethod(node) {
+	return Boolean(node) &&
+		node.type === 'CallExpression' &&
+		node.callee.type === 'MemberExpression' &&
+		node.callee.object.type === 'Identifier' &&
+		node.callee.object.name === 'Promise' &&
+		staticMethods.indexOf(getPropertyName(node.callee)) !== -1;
+}
+
+function isNewPromise(node) {
+	return Boolean(node) &&
+		node.type === 'NewExpression' &&
+		node.callee.type === 'Identifier' &&
+		node.callee.name === 'Promise';
+}
+
+function isPromise(node) {
+	return containsThenOrCatch(node) ||
+		isPromiseStaticMethod(node) ||
+		isNewPromise(node);
+}
+
+module.exports = isPromise;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "Utility"
   ],
   "dependencies": {
-    "lodash.get": "^4.4.2"
+    "lodash.get": "^4.4.2",
+    "lodash.zip": "^4.2.0"
   },
   "devDependencies": {
     "ava": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
     "reporter": [
       "lcov",
       "text"
-    ]
+    ],
+    "check-coverage": true,
+    "lines": 100,
+    "statements": 100,
+    "functions": 100,
+    "branches": 100
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -174,6 +174,51 @@ function create(context) {
 }
 ```
 
+### astUtils.computeStaticExpression(node)
+
+Get the value of an expression that can be statically computed, i.e. without variables references or expressions too complex.
+
+Returns:
+- `undefined` if the value could not be statically computed.
+- An object with a `value` property containing the computed value.
+
+Example:
+```js
+foo
+// => undefined
+42
+// => {value: 42}
+'foo'
+// => {value: 'foo'}
+undefined
+// => {value: undefined}
+null
+// => {value: null}
+1 + 2 - 4 + (-1)
+// => {value: -2}
+true ? 1 : 2
+// => {value: 1}
+`foo ${'bar'}`
+// => {value: 'foo bar'}
+```
+
+Usage example:
+```js
+function create(context) {
+	return {
+		TemplateLiteral(node) {
+			const expression = astUtils.computeStaticExpression(node);
+			if (expression) {
+				context.report({
+					node: node,
+					message: `You can replace this template literal by the regular string '${expression.value}'.`
+				});
+			}
+		}
+	};
+}
+```
+
 ## License
 
 MIT © [Jeroen Engels](https://github.com/jfmengels)

--- a/readme.md
+++ b/readme.md
@@ -219,6 +219,64 @@ function create(context) {
 }
 ```
 
+### astUtils.isPromise(node)
+
+Checks whether `node` is a Promise.
+
+Returns `true` if and only if `node` is one of the following:
+- a call of an expression's `then` or `catch` properties
+- a call to `Promise.resolve`, `Promise.reject`, `Promise.race` or `Promise.all`
+- a call to `new Promise`
+
+If `node` uses unknown properties of a value that would be considered a Promise, `node` itself would not be considered as a Promise. Also, any unknown method of `Promise` is not considered as a Promise.
+
+Example:
+```js
+foo.then(fn);
+// => true
+foo.catch(fn);
+// => true
+foo.then(fn).catch(fn);
+// => true
+foo.then(fn).isFulfilled(fn); // isFulfilled(fn) may not return a Promise
+// => false
+
+Promise.resolve(value);
+// => true
+Promise.reject(value);
+// => true
+Promise.race(promises);
+// => true
+Promise.all(promises);
+// => true
+Promise.map(promises, fn);
+// => false
+
+new Promise(fn);
+// => true
+new Promise.resolve(value);
+// => false
+```
+
+Usage example:
+```js
+function create(context) {
+	function reportIfPromise(node) {
+		if (astUtils.isPromise(node)) {
+			context.report({
+				node: node,
+				message: 'Prefer using async/await'
+			});
+		}
+	}
+
+	return {
+		CallExpression: reportIfPromise,
+		NewExpression: reportIfPromise
+	};
+}
+```
+
 ## License
 
 MIT © [Jeroen Engels](https://github.com/jfmengels)

--- a/readme.md
+++ b/readme.md
@@ -133,6 +133,47 @@ This is a shorthand version of [`containsIdentifier`](#astutilscontainsidentifie
 astUtils.someContainIdentifier('a', [node1, node2, node3]);
 ```
 
+### astUtils.getPropertyName(node)
+
+Get the name of a `MemberExpression`'s property. Returns:
+- a `string` if the property is accessed through dot notation.
+- a `string` if the property is accessed through brackets and is a string.
+- a `number` if the property is accessed through brackets and is a number.
+- `undefined` if `node` is not a `MemberExpression`
+- `undefined` if the property name is a hard to compute expression.
+
+Example:
+```js
+foo.bar
+// => 'bar'
+foo['bar']
+// => 'bar'
+foo[bar]
+// => undefined
+foo[0]
+// => 0 # Number
+foo[null]
+// => null
+foo[undefined]
+// => undefined
+```
+
+Usage example:
+```js
+function create(context) {
+	return {
+		MemberExpression(node) {
+			if (astUtils.getPropertyName(node).startsWith('_')) {
+				context.report({
+					node: node,
+					message: 'Don\'t access "private" fields'
+				});
+			}
+		}
+	};
+}
+```
+
 ## License
 
 MIT © [Jeroen Engels](https://github.com/jfmengels)

--- a/test/compute-static-expression.js
+++ b/test/compute-static-expression.js
@@ -1,0 +1,170 @@
+import test from 'ava';
+import lib from '../';
+import babel from './helpers/babel';
+import espree from './helpers/espree';
+
+const toValue = value => ({value});
+
+[espree, babel].forEach(({name, utils}) => {
+	test(`(${name}) should return undefined if node is a not an expression`, t => {
+		t.true(undefined === lib.computeStaticExpression(null));
+		t.true(undefined === lib.computeStaticExpression(utils.statement(`foo = 2`)));
+		t.true(undefined === lib.computeStaticExpression(utils.program(`foo = 2`)));
+	});
+
+	test(`(${name}) should return undefined if node is a variable name`, t => {
+		t.true(undefined === lib.computeStaticExpression(utils.expression(`foo`)));
+	});
+
+	test(`(${name}) should return value undefined if node is the 'undefined' Literal`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`undefined`)), toValue(undefined));
+	});
+
+	test(`(${name}) should return the node's value if node is a Literal`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`null`)), toValue(null));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`'foo'`)), toValue('foo'));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`0`)), toValue(0));
+	});
+
+	test(`(${name}) should return the value if node is a Literal`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`null`)), toValue(null));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`'foo'`)), toValue('foo'));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`'undefined'`)), toValue('undefined'));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`'null'`)), toValue('null'));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`0`)), toValue(0));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`1`)), toValue(1));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`0.5`)), toValue(0.5));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`.5`)), toValue(0.5));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`0x90`)), toValue(144));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`true`)), toValue(true));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`false`)), toValue(false));
+	});
+
+	test(`(${name}) should return the node's content if node is a TemplateLiteral without dynamic content`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression('``')), toValue(''));
+		t.deepEqual(lib.computeStaticExpression(utils.expression('`foo`')), toValue('foo'));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`\`foo
+bar\``)), toValue('foo\nbar'));
+	});
+
+	test(`(${name}) should return the node's content if node is a TemplateLiteral with dynamic content that is statically knowable`, t => {
+		/* eslint-disable no-template-curly-in-string */
+		t.deepEqual(lib.computeStaticExpression(utils.expression('`foo ${"bar"}`')), toValue('foo bar'));
+		t.deepEqual(lib.computeStaticExpression(utils.expression('`foo ${1 + 2}`')), toValue('foo 3'));
+		/* eslint-enable no-template-curly-in-string */
+	});
+
+	test(`(${name}) should return undefined if node is a TemplateLiteral with dynamic content`, t => {
+		/* eslint-disable no-template-curly-in-string */
+		t.true(undefined === lib.computeStaticExpression(utils.expression('`foo ${bar}`')));
+		t.true(undefined === lib.computeStaticExpression(utils.expression('`${foo}`')));
+		t.true(undefined === lib.computeStaticExpression(utils.expression('`${foo} ${"foo"}`')));
+		/* eslint-enable no-template-curly-in-string */
+	});
+
+	test(`(${name}) should return the value if node is a unary expression`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`+1`)), toValue(+1));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`-1`)), toValue(-1));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`~1`)), toValue(-2));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`!1`)), toValue(false));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`!0`)), toValue(true));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`!!0`)), toValue(false));
+	});
+
+	test(`(${name}) should return the value of a number addition`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`0 + 1`)), toValue(1));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`0 + -1`)), toValue(-1));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`0b110 + 1`)), toValue(7));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`0x90 + 1`)), toValue(145));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 + 1`)), toValue(101));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`1 + 2 + 3`)), toValue(6));
+	});
+
+	test(`(${name}) should return the value of a string concatenation`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`'0' + '1'`)), toValue('01'));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`'foo' + 'bar'`)), toValue('foobar'));
+	});
+
+	test(`(${name}) should return the value of a mixed types addition`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`'foo' + 0`)), toValue('foo0'));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`0 + 'foo'`)), toValue('0foo'));
+	});
+
+	test(`(${name}) should return the value of a number subtraction`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 - 1`)), toValue(99));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 - 2 - 1`)), toValue(97));
+	});
+
+	test(`(${name}) should return the value of a logical expression`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`true && false`)), toValue(false));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`true || false`)), toValue(true));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`false && true`)), toValue(false));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`false || true`)), toValue(true));
+	});
+
+	test(`(${name}) should return the value of other binary operators`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 % 3`)), toValue(1));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 ** 2`)), toValue(10000));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 + 2 ** 2`)), toValue(104));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 << 2`)), toValue(400));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 >> 2`)), toValue(25));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 >>> 2`)), toValue(25));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`10 & 2`)), toValue(2));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 | 2`)), toValue(102));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`10 ^ 2`)), toValue(10));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`1 === 1`)), toValue(true));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`1 !== 1`)), toValue(false));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`1 == 1`)), toValue(true));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`1 != 1`)), toValue(false));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`1 < 2`)), toValue(true));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`1 > 2`)), toValue(false));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`1 <= 2`)), toValue(true));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`1 >= 2`)), toValue(false));
+	});
+
+	test(`(${name}) should return the value of multiplication`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 * 2`)), toValue(200));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 * 2 + 1`)), toValue(201));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 + 2 * 1`)), toValue(102));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`(100 + 2) * 10`)), toValue(1020));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 - 2 * 1`)), toValue(98));
+	});
+
+	test(`(${name}) should return the value of division`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 / 2`)), toValue(50));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 / 2 + 1`)), toValue(51));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 + 20 / 2`)), toValue(110));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`(100 + 20) / 2`)), toValue(60));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`100 + (20 / 2)`)), toValue(110));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`10 * 20 / 2`)), toValue(100));
+	});
+
+	test(`(${name}) should return the value of a ternary expression`, t => {
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`true ? 1 : 2`)), toValue(1));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`false ? 1 : 2`)), toValue(2));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`true ? 1 : foo`)), toValue(1));
+		t.deepEqual(lib.computeStaticExpression(utils.expression(`false ? foo : 2`)), toValue(2));
+	});
+
+	test(`(${name}) should undefined if one of the operands of a ternary expression is not statically knowable`, t => {
+		t.true(undefined === lib.computeStaticExpression(utils.expression(`foo ? 1 : 2`)));
+		t.true(undefined === lib.computeStaticExpression(utils.expression(`true ? foo : 2`)));
+		t.true(undefined === lib.computeStaticExpression(utils.expression(`false ? 1 : foo`)));
+	});
+
+	test(`(${name}) should return undefined if the value of a unary expression is not statically knowable`, t => {
+		t.true(undefined === lib.computeStaticExpression(utils.expression(`!foo`)));
+	});
+
+	test(`(${name}) should return undefined if one of the value of a binary expression is not statically knowable`, t => {
+		t.true(undefined === lib.computeStaticExpression(utils.expression(`foo + 0`)));
+		t.true(undefined === lib.computeStaticExpression(utils.expression(`0 + foo`)));
+	});
+
+	test(`(${name}) should return undefined if one of the value of a logical expression is not statically knowable`, t => {
+		t.true(undefined === lib.computeStaticExpression(utils.expression(`foo || true`)));
+		t.true(undefined === lib.computeStaticExpression(utils.expression(`foo && true`)));
+		t.true(undefined === lib.computeStaticExpression(utils.expression(`true || foo`)));
+		t.true(undefined === lib.computeStaticExpression(utils.expression(`true && foo`)));
+	});
+});

--- a/test/get-property-name.js
+++ b/test/get-property-name.js
@@ -1,0 +1,44 @@
+import test from 'ava';
+import lib from '../';
+import babel from './helpers/babel';
+import espree from './helpers/espree';
+
+[espree, babel].forEach(({name, utils}) => {
+	test(`(${name}) should return undefined if node is not a MemberExpression`, t => {
+		t.true(undefined === lib.getPropertyName(null));
+		t.true(undefined === lib.getPropertyName(utils.expression(`null`)));
+		t.true(undefined === lib.getPropertyName(utils.expression(`42`)));
+		t.true(undefined === lib.getPropertyName(utils.expression('`42`')));
+		t.true(undefined === lib.getPropertyName(utils.expression('foo')));
+		t.true(undefined === lib.getPropertyName(utils.expression('foo()')));
+		t.true(undefined === lib.getPropertyName(utils.expression('foo.bar()')));
+	});
+
+	test(`(${name}) should return the name of the property if node is non-computed and property is an Identifier`, t => {
+		t.true(lib.getPropertyName(utils.expression(`foo.bar`)) === 'bar');
+		t.true(lib.getPropertyName(utils.expression(`foo.bar.baz`)) === 'baz');
+		t.true(lib.getPropertyName(utils.expression(`foo().bar`)) === 'bar');
+		t.true(lib.getPropertyName(utils.expression(`foo().bar`)) === 'bar');
+		t.true(lib.getPropertyName(utils.expression(`foo.null`)) === 'null');
+		t.true(lib.getPropertyName(utils.expression(`foo.undefined`)) === 'undefined');
+	});
+
+	test(`(${name}) should return the value of the property if it is an Literal`, t => {
+		t.true(lib.getPropertyName(utils.expression(`foo['bar']`)) === 'bar');
+		t.true(lib.getPropertyName(utils.expression(`foo.bar['baz']`)) === 'baz');
+		t.true(lib.getPropertyName(utils.expression(`foo()['bar']`)) === 'bar');
+		t.true(lib.getPropertyName(utils.expression(`foo[null]`)) === null);
+		t.true(lib.getPropertyName(utils.expression(`foo[undefined]`)) === undefined);
+	});
+
+	test(`(${name}) should return the index as a number of the property if it is a number`, t => {
+		t.true(lib.getPropertyName(utils.expression(`foo[0]`)) === 0);
+	});
+
+	test(`(${name}) should return undefined if the property is an expression`, t => {
+		t.true(undefined === lib.getPropertyName(utils.expression(`foo[bar]`)));
+		t.true(undefined === lib.getPropertyName(utils.expression(`foo[bar()]`)));
+		t.true(undefined === lib.getPropertyName(utils.expression(`foo[bar + baz]`)));
+		t.true(undefined === lib.getPropertyName(utils.expression(`foo[0 + 0]`)));
+	});
+});

--- a/test/get-property-name.js
+++ b/test/get-property-name.js
@@ -23,7 +23,7 @@ import espree from './helpers/espree';
 		t.true(lib.getPropertyName(utils.expression(`foo.undefined`)) === 'undefined');
 	});
 
-	test(`(${name}) should return the value of the property if it is an Literal`, t => {
+	test(`(${name}) should return the value of the property if it is a Literal`, t => {
 		t.true(lib.getPropertyName(utils.expression(`foo['bar']`)) === 'bar');
 		t.true(lib.getPropertyName(utils.expression(`foo.bar['baz']`)) === 'baz');
 		t.true(lib.getPropertyName(utils.expression(`foo()['bar']`)) === 'bar');
@@ -35,10 +35,15 @@ import espree from './helpers/espree';
 		t.true(lib.getPropertyName(utils.expression(`foo[0]`)) === 0);
 	});
 
-	test(`(${name}) should return undefined if the property is an expression`, t => {
+	test(`(${name}) should return the index as a number of the property is a statically knowable expression`, t => {
+		t.true(lib.getPropertyName(utils.expression(`foo['th' + 'en']`)) === 'then');
+		t.true(lib.getPropertyName(utils.expression(`foo[1 + 2]`)) === 3);
+	});
+
+	test(`(${name}) should return undefined if the property is an expression that is not statically knowable`, t => {
 		t.true(undefined === lib.getPropertyName(utils.expression(`foo[bar]`)));
 		t.true(undefined === lib.getPropertyName(utils.expression(`foo[bar()]`)));
 		t.true(undefined === lib.getPropertyName(utils.expression(`foo[bar + baz]`)));
-		t.true(undefined === lib.getPropertyName(utils.expression(`foo[0 + 0]`)));
+		t.true(undefined === lib.getPropertyName(utils.expression(`foo[0 + bar]`)));
 	});
 });

--- a/test/is-promise.test.js
+++ b/test/is-promise.test.js
@@ -1,0 +1,75 @@
+import test from 'ava';
+import lib from '../';
+import babel from './helpers/babel';
+import espree from './helpers/espree';
+
+[espree, babel].forEach(({name, utils}) => {
+	test(`(${name}) should return false if node is falsy or not a node`, t => {
+		t.false(lib.isPromise(null));
+		t.false(lib.isPromise(undefined));
+		t.false(lib.isPromise({}));
+		t.false(lib.isPromise('foo'));
+	});
+
+	test(`(${name}) should return true if node is call expression which calls '.then()'`, t => {
+		t.true(lib.isPromise(utils.expression(`foo.then(fn)`)));
+		t.true(lib.isPromise(utils.expression(`foo().then(fn)`)));
+		t.true(lib.isPromise(utils.expression(`foo['then'](fn)`)));
+		t.true(lib.isPromise(utils.expression(`foo['th' + 'en'](fn)`)));
+
+		t.false(lib.isPromise(utils.expression(`foo().bar(fn)`)));
+		t.false(lib.isPromise(utils.expression(`then(fn)`)));
+		t.false(lib.isPromise(utils.expression(`foo['bar'](fn)`)));
+		t.false(lib.isPromise(utils.expression(`foo[0](fn)`)));
+	});
+
+	test(`(${name}) should return true if node is call expression which calls '.catch()'`, t => {
+		t.true(lib.isPromise(utils.expression(`foo.catch(fn)`)));
+		t.true(lib.isPromise(utils.expression(`foo().catch(fn)`)));
+		t.true(lib.isPromise(utils.expression(`foo['catch'](fn)`)));
+	});
+
+	test(`(${name}) should return false when accessing a property of a Promise`, t => {
+		t.false(lib.isPromise(utils.expression(`foo.then(fn).foo`)));
+		t.false(lib.isPromise(utils.expression(`foo.catch(fn).foo`)));
+	});
+
+	test(`(${name}) should return false when calling a property of a Promise`, t => {
+		t.false(lib.isPromise(utils.expression(`foo.then(fn).map(fn)`)));
+		t.false(lib.isPromise(utils.expression(`foo.catch(fn).map(fn)`)));
+	});
+
+	test(`(${name}) should return true when expression is a call to 'Promise.{resolve|reject|race|all}()`, t => {
+		t.true(lib.isPromise(utils.expression(`Promise.resolve(fn)`)));
+		t.true(lib.isPromise(utils.expression(`Promise.resolve(fn).then(fn)`)));
+		t.true(lib.isPromise(utils.expression(`Promise.resolve(fn).catch(fn)`)));
+		t.true(lib.isPromise(utils.expression(`Promise.reject(fn)`)));
+		t.true(lib.isPromise(utils.expression(`Promise.race(fn)`)));
+		t.true(lib.isPromise(utils.expression(`Promise.all(fn)`)));
+		t.true(lib.isPromise(utils.expression(`Promise['resolve'](fn)`)));
+		t.true(lib.isPromise(utils.expression(`Promise['reject'](fn)`)));
+		t.true(lib.isPromise(utils.expression(`Promise['race'](fn)`)));
+		t.true(lib.isPromise(utils.expression(`Promise['all'](fn)`)));
+
+		t.false(lib.isPromise(utils.expression(`Promise.foo(fn)`)));
+		t.false(lib.isPromise(utils.expression(`bar.resolve(fn)`)));
+		t.false(lib.isPromise(utils.expression(`bar.reject(fn)`)));
+		t.false(lib.isPromise(utils.expression(`bar.race(fn)`)));
+		t.false(lib.isPromise(utils.expression(`bar.all(fn)`)));
+		t.false(lib.isPromise(utils.expression(`foo.Promise.resolve(fn)`)));
+		t.false(lib.isPromise(utils.expression(`Promise.resolve(fn).map(fn)`)));
+	});
+
+	test(`(${name}) should return true when calling 'new Promise(fn)'`, t => {
+		t.true(lib.isPromise(utils.expression(`new Promise(fn);`)));
+		t.true(lib.isPromise(utils.expression(`new Promise(fn).then();`)));
+
+		t.false(lib.isPromise(utils.expression(`Promise(fn)`)));
+		t.false(lib.isPromise(utils.expression(`new Promise(fn).map(fn)`)));
+		t.false(lib.isPromise(utils.expression(`new Foo(fn)`)));
+		t.false(lib.isPromise(utils.expression(`new Foo.bar(fn)`)));
+		t.false(lib.isPromise(utils.expression(`new Promise.bar(fn)`)));
+		t.false(lib.isPromise(utils.expression(`new Promise.resolve(fn)`)));
+		t.false(lib.isPromise(utils.expression(`new Foo.resolve(fn)`)));
+	});
+});


### PR DESCRIPTION
Fixes #6. This PR adds a `isPromise` function to the library.

I have a few things I'm not sure about and would appreciate some feedback.

1. I currently allow Promise with no parameters. i.e., I accept `new Promise()`, `foo.then()`, `Promise.all()`. I wonder whether I should add a new check that verifies that there is at least one argument. I'm leaning towards not doing it, so that someone could easily write a rule that warns when there is no argument for the methods that actually require it.

2. I currently do not consider any called properties of a Promise as a Promise. i.e., `foo.then().finally()` is not considered a Promise. Bluebird for example has `.isFulfilled()`, which returns a boolean, in which case this would be false. This differs from @xjamundx's [implementation](https://github.com/xjamundx/eslint-plugin-promise/blob/master/rules/lib/is-promise.js). I think this is safer generally, but it's simply a false positive vs false negative trade-off.

3. I'm wondering about adding an optional options parameter, to allow to override point 2, i.e. either accept property call (for either any or some properties) to be considered to be a Promise. This would allow better interop with Promise libraries like Bluebird, or to even write a Bluebird promise library.

4. Also, I would love adding support for more complex stuff that would require the scope information to be passed (`context.getScope()`) (though I don't want to get into that at the moment). I think that the scope could be added as an option (like in point 3).
Some examples:
- Calling an async function
- `const { resolve } = Promise; resolve();` Not necessarily useful, but I know it's sometimes used when requiring Bluebird
- `const foo = a.then(fn); foo;` Checking expressions. Here `foo` should be considered as a Promise
- Use available type information to detect Promises (one day...)
- others...?

@xjamundx and @sindresorhus, if you have the time to give some input, I'd appreciate it :)

Also, if you think of some functions that you use more often (getting the parameters of a Promise) related to this that would help complement this addition, let me know.

As a side-note @xjamundx, your implementation lacks recognizing `new Promise(fn)` as a Promise at the moment.